### PR TITLE
fix: resolve compiler warnings for unused imports and dead code

### DIFF
--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -10,7 +10,7 @@
 mod detector;
 pub mod manager;
 
-pub use manager::{failed_status, HotkeyManager, HotkeyStatus};
+pub use manager::{HotkeyManager, HotkeyStatus};
 
 use evdev::Key;
 

--- a/src-tauri/src/state_machine.rs
+++ b/src-tauri/src/state_machine.rs
@@ -88,9 +88,9 @@ pub enum Effect {
     StartAudio { id: Uuid },
     StopAudio { id: Uuid },
     StartTranscription { id: Uuid, wav_path: PathBuf },
-    CopyToClipboard { id: Uuid, text: String },
+    CopyToClipboard { _id: Uuid, text: String },
     StartDoneTimeout { id: Uuid, duration: Duration },
-    Cleanup { id: Uuid, wav_path: Option<PathBuf> },
+    Cleanup { _id: Uuid, wav_path: Option<PathBuf> },
     /// Signal to emit UI state to the frontend
     EmitUi,
 }
@@ -149,7 +149,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             },
             vec![
                 Cleanup {
-                    id: *recording_id,
+                    _id: *recording_id,
                     wav_path: None,
                 },
                 EmitUi,
@@ -161,7 +161,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
                 // Stop audio in case it started between cancel and AudioStartOk
                 StopAudio { id: *recording_id },
                 Cleanup {
-                    id: *recording_id,
+                    _id: *recording_id,
                     wav_path: None,
                 },
                 EmitUi,
@@ -184,7 +184,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             vec![
                 StopAudio { id: *recording_id },
                 Cleanup {
-                    id: *recording_id,
+                    _id: *recording_id,
                     wav_path: Some(wav_path.clone()),
                 },
                 EmitUi,
@@ -214,7 +214,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             },
             vec![
                 Cleanup {
-                    id: *recording_id,
+                    _id: *recording_id,
                     wav_path: Some(wav_path.clone()),
                 },
                 EmitUi,
@@ -231,7 +231,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             },
             vec![
                 CopyToClipboard {
-                    id: *recording_id,
+                    _id: *recording_id,
                     text,
                 },
                 StartDoneTimeout {
@@ -262,7 +262,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             Idle,
             vec![
                 Cleanup {
-                    id: *recording_id,
+                    _id: *recording_id,
                     wav_path: Some(wav_path.clone()),
                 },
                 EmitUi,
@@ -277,7 +277,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             Idle,
             vec![
                 Cleanup {
-                    id: *recording_id,
+                    _id: *recording_id,
                     wav_path: None,
                 },
                 EmitUi,


### PR DESCRIPTION
## Summary
- Remove unused `failed_status` re-export from `hotkey/mod.rs` (function is already imported directly in `lib.rs`)
- Prefix `id` fields with underscore (`_id`) in `CopyToClipboard` and `Cleanup` effects to suppress warnings while preserving the fields for Sprint 4 transcription tracking

## Changes
| File | Change |
|------|--------|
| `src-tauri/src/hotkey/mod.rs` | Remove `failed_status` from pub use |
| `src-tauri/src/state_machine.rs` | Rename `id` to `_id` in Effect variants |

## Test plan
- [ ] Verify `cargo build 2>&1 | grep -E "^warning:"` produces no warnings

Closes #30