### PR TITLE
Add environment variable configuration support via .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# VoKey Transcribe Environment Configuration
+# Copy this file to .env and fill in your values
+
+# OpenAI API Key (required for transcription)
+# Get your key at: https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-your-api-key-here

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -875,6 +875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4916,6 +4922,7 @@ dependencies = [
  "arboard",
  "cpal",
  "dirs 5.0.1",
+ "dotenvy",
  "evdev",
  "hound",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,3 +40,6 @@ arboard = "3"
 
 # XDG paths
 dirs = "5"
+
+# Development environment
+dotenvy = "0.15"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Load .env file if present (for development convenience)
+    // Silently ignore if not found - production uses system env vars
+    let _ = dotenvy::dotenv();
+
     app_lib::run();
 }


### PR DESCRIPTION
## Summary
This PR adds support for loading environment variables from a `.env` file during development, improving the developer experience by eliminating the need to manually set environment variables for local testing.

## Changes
- **Added `.env.example`**: Template file documenting required environment variables (OpenAI API Key) with instructions for setup
- **Added `dotenvy` dependency**: Lightweight Rust crate for loading `.env` files, added to `Cargo.toml` and `Cargo.lock`
- **Updated `main.rs`**: Integrated `dotenvy::dotenv()` call at application startup to load environment variables from `.env` file if present
- **Graceful fallback**: Implementation silently ignores missing `.env` file, allowing production deployments to rely on system environment variables

## Implementation Details
- The `dotenvy::dotenv()` call is placed at the very start of `main()` before any other initialization
- Error handling uses `let _ =` to intentionally ignore the result, as the `.env` file is optional
- This approach maintains backward compatibility with existing deployment methods that use system environment variables
- Developers can now simply copy `.env.example` to `.env` and fill in their API keys for local development