### PR TITLE
Fix debug container height and scrolling behavior

### DIFF
--- a/src/styles/debug.css
+++ b/src/styles/debug.css
@@ -4,8 +4,9 @@
   font-size: 13px;
   background: #1a1a2e;
   color: #eee;
-  min-height: 100vh;
+  height: 100%;
   box-sizing: border-box;
+  overflow-y: auto;
 }
 
 .debug-container h3 {


### PR DESCRIPTION
## Summary
Updated the debug container styling to use relative height instead of viewport height, and added scrolling support for content overflow.

## Changes
- Changed `min-height: 100vh` to `height: 100%` to make the container height relative to its parent instead of the viewport
- Added `overflow-y: auto` to enable vertical scrolling when content exceeds the container's height

## Details
This change allows the debug container to properly fit within its parent container and scroll independently when needed, rather than always taking up the full viewport height. This is particularly useful when the debug panel is embedded within a larger layout where viewport-relative sizing causes layout issues.