### PR TITLE
fix(permissions): add window permissions for dragging and settings

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,9 @@
     "debug"
   ],
   "permissions": [
-    "core:default"
+    "core:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-show",
+    "core:window:allow-set-focus"
   ]
 }


### PR DESCRIPTION
Add missing Tauri permissions required for:
- core:window:allow-start-dragging - enables HUD window dragging
- core:window:allow-show - enables showing settings window
- core:window:allow-set-focus - enables focusing settings window