### PR TITLE
chore: bump version to 0.2.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vokey-transcribe",
-  "version": "0.1.0",
+  "version": "0.2.0-dev",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vokey-transcribe"
-version = "0.1.0"
+version = "0.2.0-dev"
 description = "Voice-to-text transcription via global hotkey"
 authors = ["mcorrig4"]
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
- Bump package.json and Cargo.toml versions to `0.2.0-dev`
- Begins new development cycle after v0.1.0 release

## Context
This follows the release of [v0.1.0](https://github.com/mcorrig4/vokey-transcribe/releases/tag/v0.1.0).

The `-dev` suffix indicates this is a development version, not a release.

## Test plan
- [x] Version numbers updated in both files

🤖 Generated with [Claude Code](https://claude.ai/code)