### PR TITLE
docs: add git branching strategy (develop branch workflow)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,45 @@ After completing major work, checking in code, or making significant discoveries
 - **Target:** Linux (Kubuntu/KDE Plasma 6.4/Wayland)
 - **Approach:** Clipboard-only (no auto-paste), evdev for hotkeys
 
+## Git Branching Strategy
 
+This project uses a **GitHub Flow + Develop Branch** hybrid workflow:
+
+```
+master (stable releases)
+  │   • Only receives tested, stable code
+  │   • Tagged releases (v1.0.0, v1.1.0, etc.)
+  │   • PRs from develop require passing CI + manual approval
+  │
+  └── develop (integration/testing)
+        │   • Default branch for all PRs
+        │   • Integration branch for testing multiple features together
+        │   • Merge to master when ready for release
+        │
+        ├── claude/feature-branch-*
+        └── feat/manual-work
+```
+
+### Branch Workflow
+
+1. **Feature Development**
+   - Create feature branches from `develop`
+   - Open PRs targeting `develop` (not master)
+   - Merge to `develop` after review
+
+2. **Integration Testing**
+   - Test combined features on `develop`
+   - Fix integration issues before promoting
+
+3. **Release to Master**
+   - Create PR from `develop` → `master`
+   - Tag releases on master (e.g., `v1.0.0`)
+
+### PR Conventions
+
+- All PRs should target `develop` unless explicitly releasing to master
+- Use conventional commit messages in PR titles
+- Link related issues with "Closes #XX" or "Part of #XX"
 
 ## LXD Container Development
 

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -132,6 +132,22 @@ This document tracks progress, decisions, and context for the VoKey Transcribe p
 - Logs: `~/.local/share/vokey-transcribe/logs/`
 - Temp audio: `~/.local/share/vokey-transcribe/temp/audio/`
 
+### AD-004: Git Branching Strategy (GitHub Flow + Develop)
+**Date:** 2026-01-27
+**Decision:** Use hybrid GitHub Flow with a `develop` integration branch
+**Branches:**
+- `master` - Stable releases only, tagged versions
+- `develop` - Integration/testing branch, default PR target
+- `claude/*`, `feat/*` - Feature branches
+
+**Rationale:**
+- Enables testing multiple PRs together before release
+- Protects master from untested code
+- Simple enough for small team + AI development
+- Works well with parallel feature development (Sprint 7A + 7B)
+
+**Trade-off:** Extra step to promote `develop` → `master` for releases
+
 ---
 
 ## Known Issues / Risks
@@ -158,6 +174,27 @@ This document tracks progress, decisions, and context for the VoKey Transcribe p
 ---
 
 ## Session Notes
+
+### Session 2026-01-27 (Git Workflow Setup)
+**Implemented GitHub Flow + Develop branch strategy:**
+
+**Changes Made:**
+- Created `develop` branch from `master` via GitHub API
+- Retargeted all 5 open PRs (#90, #105, #106, #107, #108) to `develop`
+- Updated CLAUDE.md with branching workflow documentation
+- Added AD-004 architecture decision
+
+**Manual Steps Required (admin access):**
+- [ ] Set `develop` as default branch in GitHub Settings
+- [ ] Add branch protection rules for `master` and `develop`
+
+**New Workflow:**
+1. All PRs target `develop` for integration testing
+2. Test combined features on `develop`
+3. Create release PRs from `develop` → `master`
+4. Tag releases on `master`
+
+---
 
 ### Session 2026-01-24 (Sprint 7B Planning)
 **Analyzed options and created Sprint 7B plan:**


### PR DESCRIPTION
## Summary

- Add GitHub Flow + Develop hybrid workflow documentation to CLAUDE.md
- Add AD-004 architecture decision to WORKLOG.md
- Document session notes for git workflow setup

This documents the new branching strategy where:
- All PRs target `develop` (integration branch)
- `master` only receives stable, tested code
- Releases are tagged on master

## Test plan

- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)