### PR TITLE
fix: replace maximize/unmaximize hack with GTK titlebar removal (tao#1046)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4979,6 +4979,7 @@ dependencies = [
  "dotenvy",
  "evdev",
  "futures-util",
+ "gtk",
  "hound",
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,9 @@ futures-util = "0.3"
 # XDG paths
 dirs = "5"
 
+# GTK (Linux window customization)
+gtk = "0.18"
+
 # Development environment
 dotenvy = "0.15"
 once_cell = "1.19"


### PR DESCRIPTION
## Summary

Replaces the unreliable maximize/unmaximize workaround for Wayland CSD issues with a proper fix that removes GTK's custom titlebar, allowing KDE to provide native server-side decorations.

## Problem

On KDE Plasma/Wayland, GTK's client-side decorations (CSD) cause window control buttons to not work ([tao#1046](https://github.com/tauri-apps/tao/issues/1046)). The previous workaround:
- Was unreliable (50ms delay often wasn't enough)
- Caused ugly visual glitches (window flashing to maximized then back)

## Solution

Remove GTK's custom titlebar at startup so KDE provides native decorations:

```rust
#[cfg(target_os = "linux")]
{
    use gtk::prelude::GtkWindowExt;
    if let Ok(gtk_window) = window.gtk_window() {
        gtk_window.set_titlebar(Option::<&gtk::Widget>::None);
    }
}
```

## Changes

- Add `gtk = "0.18"` dependency
- Call `gtk_window.set_titlebar(None)` in setup for debug window
- Simplify `open_settings_window_impl` (no longer needs the hack)
- Update `tauri-gotchas.md` with new solution

## Test Plan

- [ ] Build passes on Linux
- [ ] Settings window opens without visual glitches
- [ ] Window control buttons (minimize, maximize, close) work on first open
- [ ] Window looks native to KDE

## Related

- Closes workaround for [tao#1046](https://github.com/tauri-apps/tao/issues/1046)
- See #112 for future tauri-controls implementation

🤖 Generated with [Claude Code](https://claude.ai/code)