### PR TITLE
fix: enable quit button and allow HUD window dragging

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-start-dragging",
     "core:window:allow-show",
     "core:window:allow-set-focus",
-    "process:allow-restart"
+    "process:allow-restart",
+    "process:allow-exit"
   ]
 }

--- a/src-tauri/src/kwin.rs
+++ b/src-tauri/src/kwin.rs
@@ -184,7 +184,7 @@ fn install_rule(path: &PathBuf) -> Result<(), String> {
     rule_section.insert("acceptfocus".to_string(), "false".to_string());
     rule_section.insert("acceptfocusrule".to_string(), "2".to_string());
     rule_section.insert("position".to_string(), "20,20".to_string());
-    rule_section.insert("positionrule".to_string(), "2".to_string());
+    rule_section.insert("positionrule".to_string(), "4".to_string());
     rule_section.insert("wmclass".to_string(), WMCLASS.to_string());
     rule_section.insert("wmclassmatch".to_string(), "1".to_string());
 

--- a/src/components/HUD/SetupBanner.tsx
+++ b/src/components/HUD/SetupBanner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { invoke } from '@tauri-apps/api/core'
-import { relaunch } from '@tauri-apps/plugin-process'
+import { relaunch, exit } from '@tauri-apps/plugin-process'
 import styles from './SetupBanner.module.css'
 
 interface KwinSetupNeeded {
@@ -61,15 +61,21 @@ export function SetupBanner() {
     setBannerState('hidden')
   }, [])
 
+  const isDev = window.location.hostname === 'localhost'
+
   const handleRestart = useCallback(async () => {
     try {
-      await relaunch()
+      if (isDev) {
+        await exit(0)
+      } else {
+        await relaunch()
+      }
     } catch (err) {
       console.error('[SetupBanner] Failed to restart app:', err)
       // Fallback message if restart fails
-      setErrorMsg('Please restart the app manually')
+      setErrorMsg(isDev ? 'Please restart with "pnpm tauri dev"' : 'Please restart the app manually')
     }
-  }, [])
+  }, [isDev])
 
   if (bannerState === 'hidden') {
     return null
@@ -89,7 +95,7 @@ export function SetupBanner() {
             onClick={handleRestart}
             data-no-drag
           >
-            Restart Now
+            {isDev ? 'Quit App' : 'Restart Now'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `process:allow-exit` permission to fix quit button not working in dev mode
- Update SetupBanner restart button to show "Quit App" in dev mode (consistent with other quit buttons)
- Change KWin `positionrule` from Force (2) to Remember (4) to allow HUD window dragging

## Details

### Quit Button Fix
The "Quit App" button wasn't working because the `process:allow-exit` capability was missing from `src-tauri/capabilities/default.json`.

### HUD Dragging Fix
After installing the KWin rule, the HUD window was stuck at position 20,20 because `positionrule=2` (Force) was preventing dragging. Changed to `positionrule=4` (Remember) which:
- Allows users to drag the window to any position
- KWin remembers the position between restarts
- Initial position still defaults to 20,20 on first launch

## Test Plan
- [x] Verify "Quit App" button works in dev mode
- [x] Remove existing KWin rule (Debug panel → "Remove KWin Rule")
- [x] Restart the app and install new rule (SetupBanner → "Fix Now")
- [x] Verify HUD window can be dragged
- [x] Restart app → verify position is remembered

Related to #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)