### PR TITLE
fix: resolve clippy warnings and remove dead code

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -8,8 +8,6 @@ pub mod recorder;
 pub mod vad;
 mod waveform;
 
-pub use paths::{cleanup_old_recordings, create_temp_audio_dir, generate_wav_path};
-pub use recorder::{AudioError, AudioRecorder, StreamingSender};
-pub use waveform::{
-    create_waveform_channel, run_waveform_emitter, WaveformData, WaveformReceiver, WaveformSender,
-};
+pub use paths::{cleanup_old_recordings, create_temp_audio_dir};
+pub use recorder::AudioRecorder;
+pub use waveform::{create_waveform_channel, run_waveform_emitter};

--- a/src-tauri/src/audio/paths.rs
+++ b/src-tauri/src/audio/paths.rs
@@ -25,12 +25,11 @@ fn get_max_recordings() -> usize {
 /// Get the temp audio directory path.
 /// Returns: ~/.local/share/vokey-transcribe/temp/audio/
 fn temp_audio_dir() -> PathBuf {
-    let data_dir = dirs::data_local_dir()
+    dirs::data_local_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join("vokey-transcribe")
         .join("temp")
-        .join("audio");
-    data_dir
+        .join("audio")
 }
 
 /// Create the temp audio directory if it doesn't exist.

--- a/src-tauri/src/audio/waveform.rs
+++ b/src-tauri/src/audio/waveform.rs
@@ -164,9 +164,9 @@ impl EmaState {
             return;
         }
 
-        for i in 0..NUM_BARS {
+        for (bar, prev) in bars.iter_mut().zip(self.prev_bars.iter()) {
             // EMA formula: new = alpha * current + (1 - alpha) * previous
-            bars[i] = EMA_ALPHA * bars[i] + (1.0 - EMA_ALPHA) * self.prev_bars[i];
+            *bar = EMA_ALPHA * *bar + (1.0 - EMA_ALPHA) * prev;
         }
 
         // Store for next frame

--- a/src-tauri/src/effects.rs
+++ b/src-tauri/src/effects.rs
@@ -146,7 +146,8 @@ fn evaluate_short_clip_vad(stats: &crate::audio::vad::VadStats) -> VadDecision {
 }
 
 /// Convenience function that returns just the boolean decision.
-/// Used by tests and any code that only needs the final answer.
+/// Used by tests that only need the final answer.
+#[cfg(test)]
 fn short_clip_vad_allows_transcription(stats: &crate::audio::vad::VadStats) -> bool {
     evaluate_short_clip_vad(stats).allows_transcription
 }

--- a/src-tauri/src/hotkey/manager.rs
+++ b/src-tauri/src/hotkey/manager.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use evdev::{Device, InputEventKind, Key};
 use tokio::sync::mpsc;
@@ -66,7 +66,7 @@ pub fn find_keyboards() -> Vec<(PathBuf, Device)> {
     evdev::enumerate()
         .filter_map(|(path, device)| {
             // A keyboard should support common keys
-            let is_keyboard = device.supported_keys().map_or(false, |keys| {
+            let is_keyboard = device.supported_keys().is_some_and(|keys| {
                 keys.contains(Key::KEY_ENTER)
                     && keys.contains(Key::KEY_SPACE)
                     && keys.contains(Key::KEY_A)

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -10,7 +10,7 @@
 mod detector;
 pub mod manager;
 
-pub use manager::{failed_status, HotkeyManager, HotkeyStatus};
+pub use manager::{HotkeyManager, HotkeyStatus};
 
 use evdev::Key;
 

--- a/src-tauri/src/kwin.rs
+++ b/src-tauri/src/kwin.rs
@@ -336,12 +336,6 @@ fn reload_kwin() -> Result<(), String> {
     }
 }
 
-/// Check if KWin setup is needed (Wayland + KDE but rules not installed)
-pub fn needs_setup() -> bool {
-    let status = get_status();
-    status.rules_applicable && !status.rule_installed
-}
-
 /// Get the current KWin status
 pub fn get_status() -> KwinStatus {
     let is_wayland = is_wayland();
@@ -351,7 +345,7 @@ pub fn get_status() -> KwinStatus {
     let config_path = kwinrulesrc_path();
     let rule_installed = config_path
         .as_ref()
-        .map(|p| check_rule_installed(p))
+        .map(check_rule_installed)
         .unwrap_or(false);
 
     KwinStatus {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -706,7 +706,7 @@ pub fn run() {
             });
 
             // Load and manage settings
-            let loaded_settings = settings::load_settings(&app.handle());
+            let loaded_settings = settings::load_settings(app.handle());
             log::info!(
                 "Settings loaded: min_transcribe_ms={}, short_clip_vad_enabled={}",
                 loaded_settings.min_transcribe_ms,

--- a/src-tauri/src/metrics.rs
+++ b/src-tauri/src/metrics.rs
@@ -137,8 +137,6 @@ pub struct MetricsCollector {
     successful_cycles: u64,
     /// Total audio chunks sent to streaming pipeline
     streaming_chunks_sent: u64,
-    /// Total audio chunks dropped (channel full or closed)
-    streaming_chunks_dropped: u64,
 }
 
 impl MetricsCollector {
@@ -151,7 +149,6 @@ impl MetricsCollector {
             total_cycles: 0,
             successful_cycles: 0,
             streaming_chunks_sent: 0,
-            streaming_chunks_dropped: 0,
         }
     }
 
@@ -202,31 +199,9 @@ impl MetricsCollector {
         }
     }
 
-    /// Increment the count of audio chunks sent to streaming pipeline
-    pub fn streaming_chunk_sent(&mut self) {
-        self.streaming_chunks_sent += 1;
-    }
-
-    /// Increment the count of audio chunks dropped (channel full or closed)
-    pub fn streaming_chunk_dropped(&mut self) {
-        self.streaming_chunks_dropped += 1;
-        if self.streaming_chunks_dropped % 100 == 1 {
-            log::warn!(
-                "Streaming: dropped chunk (total dropped: {})",
-                self.streaming_chunks_dropped
-            );
-        }
-    }
-
-    /// Get streaming metrics (sent, dropped)
-    pub fn get_streaming_stats(&self) -> (u64, u64) {
-        (self.streaming_chunks_sent, self.streaming_chunks_dropped)
-    }
-
-    /// Reset streaming metrics (call at start of each recording)
+    /// Reset streaming chunks counter (call at start of each recording)
     pub fn reset_streaming_stats(&mut self) {
         self.streaming_chunks_sent = 0;
-        self.streaming_chunks_dropped = 0;
     }
 
     /// Add streaming chunks sent (for bulk update after streaming completes)

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -99,12 +99,10 @@ pub fn save_settings(app: &AppHandle, settings: &AppSettings) -> Result<(), Stri
 
     // On Unix, rename will atomically replace the destination. On Windows, rename
     // fails if the destination exists, so we remove it first (ignoring NotFound).
-    if cfg!(windows) {
-        if path.exists() {
-            if let Err(e) = std::fs::remove_file(&path) {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    return Err(format!("Remove existing settings file {:?}: {}", path, e));
-                }
+    if cfg!(windows) && path.exists() {
+        if let Err(e) = std::fs::remove_file(&path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                return Err(format!("Remove existing settings file {:?}: {}", path, e));
             }
         }
     }

--- a/src-tauri/src/state_machine.rs
+++ b/src-tauri/src/state_machine.rs
@@ -27,8 +27,9 @@ impl NoSpeechSource {
 
 /// Internal state of the recording workflow.
 /// This is the authoritative state - all transitions go through the reducer.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum State {
+    #[default]
     Idle,
     Arming {
         recording_id: Uuid,
@@ -66,12 +67,6 @@ pub enum State {
         message: String,
         last_good_text: Option<String>,
     },
-}
-
-impl Default for State {
-    fn default() -> Self {
-        State::Idle
-    }
 }
 
 /// Events that can trigger state transitions.
@@ -166,6 +161,7 @@ pub enum Effect {
         wav_path: PathBuf,
     },
     CopyToClipboard {
+        #[allow(dead_code)] // Kept for consistency with other effects and Debug output
         id: Uuid,
         text: String,
     },
@@ -457,6 +453,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             Transcribing {
                 recording_id,
                 wav_path,
+                ..
             },
             NoSpeechDetected {
                 id,
@@ -503,6 +500,7 @@ pub fn reduce(state: &State, event: Event) -> (State, Vec<Effect>) {
             Transcribing {
                 recording_id,
                 wav_path,
+                ..
             },
             Cancel,
         ) => (
@@ -705,6 +703,7 @@ mod tests {
         let state = State::Transcribing {
             recording_id: id,
             wav_path: PathBuf::from("/tmp/test.wav"),
+            partial_text: None,
         };
         let (next, effects) = reduce(&state, Event::Cancel);
 

--- a/src-tauri/src/streaming/realtime_client.rs
+++ b/src-tauri/src/streaming/realtime_client.rs
@@ -23,7 +23,7 @@ use tokio_tungstenite::{
     connect_async_with_config,
     tungstenite::{
         client::IntoClientRequest,
-        http::{HeaderValue, Request},
+        http::HeaderValue,
         Message,
     },
     MaybeTlsStream, WebSocketStream,


### PR DESCRIPTION
## Summary
- Remove unused streaming metrics methods and fields from MetricsCollector
- Remove unused re-exports and imports across multiple modules
- Remove dead functions (needs_setup in kwin.rs)
- Fix clippy style warnings (let_and_return, needless_range_loop, etc.)
- Use derive(Default) for State enum instead of manual impl

This PR fixes all clippy warnings that were causing CI to fail on PR #145.

## Test plan
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes
- [x] App builds and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)