### PR TITLE
fix(ci): fix cargo cache cross-OS contamination in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-ubuntu2204-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-release-
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-ubuntu2204-cargo-release-
 
       - name: Install frontend dependencies
         run: pnpm install


### PR DESCRIPTION
## Problem

The v0.3.0 release build failed with `can't find crate for 'tauri_runtime'`, `gtk`, `webkit2gtk`, `muda`, `tray_icon`, `tauri_runtime_wry`.

**Root cause:** The CI workflow runs on `ubuntu-latest` (ubuntu-24.04) while the release workflow runs on `ubuntu-22.04`. Since `${{ runner.os }}` returns `Linux` for both, the release build was falling back to CI caches from ubuntu-24.04 via the broad `${{ runner.os }}-cargo-` restore key. Compiled `.rlib` artifacts are not portable across different glibc/OS versions, causing the compilation failures.

The build completing in only ~12 seconds (vs ~5+ minutes for a real Rust compile) was the telltale sign — cargo was loading stale ubuntu-24.04 artifacts into the ubuntu-22.04 build.

## Fix

- Remove `src-tauri/target` from cached paths — compiled Rust binaries are OS-specific and cannot be shared cross-version
- Scope cache key to `ubuntu2204` to prevent any fallback to CI caches built on ubuntu-latest
- Drop the broad `${{ runner.os }}-cargo-` restore key that was matching ubuntu-latest CI caches

## Testing

Merge to develop, then re-trigger the release workflow for `v0.3.0` (or re-tag) to verify a clean build.

https://claude.ai/code/session_01KUxBpdWH9jfucGd2f99MeK