### PR TITLE
chore(release): merge develop into master for v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-ubuntu2204-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-release-
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-ubuntu2204-cargo-release-
 
       - name: Install frontend dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary

- Merges develop → master to include the CI cache fix from #215
- Fixes the v0.3.0 release build failure caused by cargo cache cross-OS contamination

## Changes since last master release

- fix(ci): fix cargo cache cross-OS contamination in release workflow (#215)
- fix: address PR #207 code review comments (#214)
- fix: admin key validation URL params and show local metrics without admin key (#208)
- feat: hide transcript panel when streaming off (#194)
- fix(ci): various CI and settings window fixes (#199, #202, #205, #206)

After merging, retag v0.3.0 to trigger a fresh release build.

https://claude.ai/code/session_01KUxBpdWH9jfucGd2f99MeK