### PR TITLE
Add center position options to HUD placement settings

### DIFF
--- a/src/components/Settings/AppearancePage.tsx
+++ b/src/components/Settings/AppearancePage.tsx
@@ -13,7 +13,7 @@ import { Palette, Monitor, Sun, Moon, Layout } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 type Theme = 'system' | 'light' | 'dark'
-type HudPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+type HudPosition = 'top-left' | 'top-middle' | 'top-right' | 'bottom-left' | 'bottom-middle' | 'bottom-right'
 
 interface AppearanceSettings {
   theme: Theme
@@ -170,11 +170,16 @@ export function AppearancePage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-2 gap-4 max-w-[300px]">
+          <div className="grid grid-cols-3 gap-4 max-w-[450px]">
             <PositionOption
               selected={settings.hudPosition === 'top-left'}
               onClick={() => updateSetting('hudPosition', 'top-left')}
               label="Top Left"
+            />
+            <PositionOption
+              selected={settings.hudPosition === 'top-middle'}
+              onClick={() => updateSetting('hudPosition', 'top-middle')}
+              label="Top Middle"
             />
             <PositionOption
               selected={settings.hudPosition === 'top-right'}
@@ -185,6 +190,11 @@ export function AppearancePage() {
               selected={settings.hudPosition === 'bottom-left'}
               onClick={() => updateSetting('hudPosition', 'bottom-left')}
               label="Bottom Left"
+            />
+            <PositionOption
+              selected={settings.hudPosition === 'bottom-middle'}
+              onClick={() => updateSetting('hudPosition', 'bottom-middle')}
+              label="Bottom Middle"
             />
             <PositionOption
               selected={settings.hudPosition === 'bottom-right'}


### PR DESCRIPTION
## Summary
Extended the HUD position options to include center placements, allowing users to position the HUD in the middle of the top or bottom of the screen in addition to the existing corner positions.

## Key Changes
- Updated `HudPosition` type to include `'top-middle'` and `'bottom-middle'` options
- Expanded the position selection grid from 2 columns to 3 columns to accommodate the new options
- Increased max-width of the grid container from 300px to 450px to properly display the 3-column layout
- Added UI components for both new center position options with appropriate labels and click handlers

## Implementation Details
- The new positions follow the same naming convention and implementation pattern as existing positions
- Grid layout changed from `grid-cols-2` to `grid-cols-3` to display 6 total options (3 top, 3 bottom)
- Each new position option uses the existing `PositionOption` component with consistent styling and behavior

https://claude.ai/code/session_01Dd6tVo83hLX1ndq5TFQrKZ